### PR TITLE
Update _card-base-styles.scss

### DIFF
--- a/src/scss/mixins/_card-base-styles.scss
+++ b/src/scss/mixins/_card-base-styles.scss
@@ -13,6 +13,7 @@
   border-radius: $global-radius-large;
   max-width: 37rem;
   text-decoration: none;
+  word-break: break-word;
 
   @include apply-utility('bg', 'core-bg');
 


### PR DESCRIPTION
adding word-break to fix the title overflow from the cards

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #6836
Before fix:
![image](https://user-images.githubusercontent.com/18111502/142589304-500465bc-611c-4a35-9ca4-6a5406b2b8f2.png)

After fix:
![image](https://user-images.githubusercontent.com/18111502/142589515-761a3187-55c8-4186-b33b-16768b555560.png)


Changes proposed in this pull request:
Update the css to wrap the heading inside the card incase of test overflow.


When you're ready to submit your PR, don't forget to add the `$-presubmit` label.
